### PR TITLE
Add support for a config file

### DIFF
--- a/flycheck-mypy.el
+++ b/flycheck-mypy.el
@@ -47,6 +47,9 @@
 
 (flycheck-def-args-var flycheck-python-mypy-args python-mypy)
 
+(flycheck-def-config-file-var flycheck-mypy.ini flycheck-mypy "mypy.ini"
+  :safe #'stringp)
+
 (flycheck-define-checker python-mypy
   "Mypy syntax checker. Requires mypy>=0.3.1.
 
@@ -58,6 +61,7 @@ E.g. when processing Python2 files, add \"--py2\".
 See URL `http://mypy-lang.org/'."
 
   :command ("mypy"
+            (config-file "--config-file" flycheck-mypy.ini)
             (eval flycheck-python-mypy-args)
             source-original)
   :error-patterns


### PR DESCRIPTION
Allows `flycheck-mypy` to look for a user's configuration (a `mypy.ini`) in the same fashion other flycheck checkers look for configuration files.