### PR TITLE
Add :working-directory based on the value of the mypy configuration file.

### DIFF
--- a/flycheck-mypy.el
+++ b/flycheck-mypy.el
@@ -50,6 +50,13 @@
 (flycheck-def-config-file-var flycheck-mypy.ini flycheck-mypy "mypy.ini"
   :safe #'stringp)
 
+(defun flycheck-mypy--find-project-root (_checker)
+  "Compute an appropriate working-directory for flycheck-mypy.
+This is either a parent directory containing a flycheck-mypy.ini, or nil."
+  (and
+   buffer-file-name
+   (locate-dominating-file buffer-file-name flycheck-mypy.ini)))
+
 (flycheck-define-checker python-mypy
   "Mypy syntax checker. Requires mypy>=0.3.1.
 
@@ -64,6 +71,7 @@ See URL `http://mypy-lang.org/'."
             (config-file "--config-file" flycheck-mypy.ini)
             (eval flycheck-python-mypy-args)
             source-original)
+  :working-directory flycheck-mypy--find-project-root
   :error-patterns
   ((error line-start (file-name) ":" line ": error:" (message) line-end)
    (warning line-start (file-name) ":" line ": note:" (message) line-end)


### PR DESCRIPTION
Fix for https://github.com/lbolla/emacs-flycheck-mypy/issues/6.

This is a simple adaptation of the [`flycheck-ruby--find-project-root`](https://github.com/flycheck/flycheck/blob/master/flycheck.el#L9971) that look-up the first directory where the setup file can be found.

For instance, given the following directory structure:

```
module/
    __init__.py
    ...
tests/
    test_xxx.py
setup.cfg
setup.py
```

If `flycheck-mypy.ini` is set to `setup.cfg`, `mypy` will be run from the root directory. 